### PR TITLE
chore(deps): bump jackson 2.21.1 → 2.21.4 (hygiene, activemq-5.15.x-TT.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <httpclient-version>4.5.13</httpclient-version>
     <httpcore-version>4.4.14</httpcore-version>
     <insight-version>1.2.0.Beta4</insight-version>
-    <jackson-version>2.21.1</jackson-version>
+    <jackson-version>2.21.4</jackson-version>
     <jackson-annotations-version>2.21</jackson-annotations-version>
     <jackson-databind-version>2.12.7.1</jackson-databind-version>
     <jasypt-version>1.9.3</jasypt-version>


### PR DESCRIPTION
## Summary

Hygiene bump only — Jackson 2.21.1 → 2.21.4 (latest 2.21 patch on Maven Central).

This is **not** a CVE patch. CVE-2026-50193 (jackson-databind `InternalNodeMapper` StackOverflowError) was audited as NOT AFFECTED on ActiveMQ across every TT-shipped branch. The broker does not call `InternalNodeMapper.nodeToString` / `toPrettyString` / `JsonNode.toString()` anywhere; Jolokia uses `json-simple` (1.x) or `jolokia-json` (2.x), not Jackson.

See `docs/security-audits/2026/CVE-2026-50193.md` in `tomitribe/cve` for the full audit (L1-L4, bytecode strings sweep, per-vector trace).

## Why bump anyway

- Defence in depth (any future code path that introduces a Jackson use case inherits the fixed code).
- NexusIQ / SBOM scans report a clean Jackson version on the shipped distribution.
- Trivial: 1-line property change, no API delta within the 2.21.x line.

## Test plan

- [ ] Jenkins stable build green
- [ ] Jenkins PR-manual build green
- [ ] Flaky-compare matrix (stable vs PR) shows no patch-induced regressions

## Branch

Base: `activemq-5.15.x-TT.x`. Latest released TT on this branch when the PR was opened: activemq-5.15.17-TT.9.

Audit trail: https://github.com/tomitribe/cve/blob/main/docs/security-audits/2026/CVE-2026-50193.md