### PR TITLE
build: add Tomitribe Nexus <repositories> block to root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1462,4 +1462,12 @@
      </properties>
    </profile>
   </profiles>
+
+  <repositories>
+    <repository>
+      <id>tomitribe-all</id>
+      <name>Tomitribe Repository</name>
+      <url>https://repository.tomitribe.com/content/groups/tomitribe/</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
## Summary
- Adds a `<repositories>` block to the root pom, pointing at `https://repository.tomitribe.com/content/groups/tomitribe/`.
- Without this, `release:prepare` on a clean local Maven cache fails to resolve Tomitribe-private artifacts (e.g. `jetty-bom-*-TT.*`, `spring-context-*-TT.*`) because the pom only declares `<distributionManagement>`, not `<repositories>`.
- Mirrors the block already present on `activemq-5.16.x-TT.x`.
- Sibling PRs on other TT branches: #226 (5.17), #227 (5.18), #228 (6.0).

## Test plan
- [ ] On a machine with an empty `~/.m2/repository/org/eclipse/jetty/jetty-bom`, run `mvn release:prepare -DdryRun=true` from this branch's HEAD — it should resolve the BOM without a custom `-s` settings file.