### PR TITLE
CVE-2026-42527: bump Apache Camel to 4.14.8 (activemq-6.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <ant-version>1.10.15</ant-version>
     <aries-version>1.1.0</aries-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>4.14.7</camel-version>
+    <camel-version>4.14.8</camel-version>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>
     <commons-collections-version>3.2.2-TT.1</commons-collections-version>
     <commons-daemon-version>1.4.1</commons-daemon-version>


### PR DESCRIPTION
Fix for CVE-2026-42527 — Apache Camel deserialization DNS side-channel (default ObjectInputFilter, CAMEL-23372).

Tracking issue: https://github.com/tomitribe/cve/issues/327
Reachability audit: https://github.com/tomitribe/cve/blob/main/docs/security-audits/2026/CVE-2026-42527.md

## Changes
- Bumped `<camel-version>` (root pom property driving the camel-bom import) `4.14.7` → `4.14.8`. Moves the whole Camel family incl. camel-jms.

## Rationale
Defense-in-depth. The audit found this branch is NOT reachable by a default ActiveMQ broker (stock activemq.xml runs no Camel route), but camel-jms 4.14.7 is shipped and the ActiveMQ↔Camel integration is a supported feature — a customer who enables a Camel JMS route consuming ObjectMessages IS exposed. 4.14.8 is the fix release for the 4.14 line (patch bump, no API change).

## How the dep was found
camel-jms is pulled via the `camel-bom` import in the root pom, version-governed by the `<camel-version>` property. Single-line property bump moves it.

## Verification
- [ ] Jenkins PR-manual build — NOT triggered in this run (VPN/Jenkins unavailable); trigger manually.
- [ ] Smoke test (post-merge)