### PR TITLE
CVE-2026-42527: bump Apache Camel to 4.21.0 (activemq-6.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <annogen-version>0.1.0</annogen-version>
     <ant-version>1.10.17</ant-version>
     <aries-version>1.1.0</aries-version>
-    <camel-version>4.20.0</camel-version>
+    <camel-version>4.21.0</camel-version>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>
     <commons-collections-version>3.2.2</commons-collections-version>
     <commons-dbcp2-version>2.14.0</commons-dbcp2-version>


### PR DESCRIPTION
Fix for CVE-2026-42527 — Apache Camel deserialization DNS side-channel (default ObjectInputFilter, CAMEL-23372).

Tracking issue: https://github.com/tomitribe/cve/issues/327
Reachability audit: https://github.com/tomitribe/cve/blob/main/docs/security-audits/2026/CVE-2026-42527.md

## Changes
- Bumped `<camel-version>` (root pom property driving the camel-bom import) `4.20.0` → `4.21.0`. Moves the whole Camel family incl. camel-jms. Aligns with upstream apache/activemq main (also at camel 4.21.0).

## Rationale
Defense-in-depth. The audit found this branch is NOT reachable by a default ActiveMQ broker (stock activemq.xml runs no Camel route), but camel-jms 4.20.0 is shipped (in advisory range 4.19.0–<4.21.0) and the ActiveMQ↔Camel integration is a supported feature — a customer who enables a Camel JMS route consuming ObjectMessages IS exposed. 4.21.0 is the fix release for the 4.19–4.20 line (minor bump within 4.x).

## How the dep was found
camel-jms is pulled via the `camel-bom` import in the root pom, version-governed by the `<camel-version>` property. Single-line property bump moves it.

## Verification
- [ ] Jenkins PR-manual build — NOT triggered in this run (VPN/Jenkins unavailable); trigger manually.
- [ ] Smoke test (post-merge)