### PR TITLE
CVE-2026-43866: bump Apache Camel to 4.14.8 (activemq-6.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <ant-version>1.10.14</ant-version>
     <aries-version>1.1.0</aries-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>4.8.6</camel-version>
+    <camel-version>4.14.8</camel-version>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>
     <commons-collections-version>3.2.2-TT.1</commons-collections-version>
     <commons-daemon-version>1.3.4</commons-daemon-version>


### PR DESCRIPTION
Fix for CVE-2026-43866 — Apache Camel camel-jms ObjectMessage/DefaultExchangeHolder deserialization (CAMEL-23373).

Tracking issue: https://github.com/tomitribe/cve/issues/335
Reachability audit: https://github.com/tomitribe/cve/blob/main/docs/security-audits/2026/CVE-2026-43866.md

## Changes
- Bumped `<camel-version>` (root pom property driving the camel-bom import) `4.8.6` → `4.14.8`. Moves the whole Camel family incl. camel-jms.

## ⚠️ Compatibility risk — needs CI
This is a **larger jump than the other 43866 PRs**: 4.8.6 → 4.14.8 crosses roughly 6 Camel minor versions (4.8 → 4.14), versus the 6.1/6.2 PRs which were single-patch bumps within 4.14.x. It is not a major-version bump (major stays 4) so it is a legitimate dependency bump, but Camel minor releases can carry API/behavioural changes. **A green CI run is required before merge.** Jenkins was not triggered in this run (VPN/Jenkins unavailable) — trigger the stable + manual-pr-trigger jobs before relying on this.

## Rationale
The audit found CVE-2026-43866 REACHABLE (conditional) on 6.0: camel-jms 4.8.6 ships the un-gated ObjectMessage deserialization sink, and the shipped `examples/conf/camel.xml` JMS-consumer route reaches it when enabled. 4.14.8 introduces the `objectMessageEnabled=false` default that closes it.

## How the dep was found
camel-jms is pulled via the `camel-bom` import in the root pom, version-governed by the `<camel-version>` property. Single-line property bump moves it.

## Verification
- [ ] Jenkins PR-manual build — NOT triggered in this run (VPN/Jenkins unavailable); trigger manually. REQUIRED given the jump size.
- [ ] Smoke test (post-merge)