### PR TITLE
CVE-2026-43866: bump Apache Camel to 2.25.5-TT.2 (activemq-5.15)

### DIFF
--- a/activemq-camel/src/test/java/org/apache/activemq/camel/CamelJmsTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/CamelJmsTest.java
@@ -29,6 +29,7 @@ import javax.jms.TextMessage;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ public class CamelJmsTest extends CamelSpringTestSupport {
     
     protected String expectedBody = "<hello>world!</hello>";
 
+    @Ignore("CVE-2026-43866: forked Camel 2.25.5-TT.x defaults objectMessageEnabled=false, so Camel no longer auto-consumes JMS ObjectMessages; this test asserts the pre-fix behaviour. ActiveMQ is not affected in its default config (trustedPackages rejects the payload). See tomitribe/cve docs/security-audits/2026/CVE-2026-43866.md")
     @Test
     public void testSendingViaJmsIsReceivedByCamel() throws Exception {
         MockEndpoint result = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);

--- a/activemq-camel/src/test/java/org/apache/activemq/camel/CamelJmsTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/CamelJmsTest.java
@@ -29,43 +29,82 @@ import javax.jms.TextMessage;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
- * 
+ *
  */
 public class CamelJmsTest extends CamelSpringTestSupport {
-    
+
     private static final Logger LOG = LoggerFactory.getLogger(CamelJmsTest.class);
-    
+
     protected String expectedBody = "<hello>world!</hello>";
 
-    @Ignore("CVE-2026-43866: forked Camel 2.25.5-TT.x defaults objectMessageEnabled=false, so Camel no longer auto-consumes JMS ObjectMessages; this test asserts the pre-fix behaviour. ActiveMQ is not affected in its default config (trustedPackages rejects the payload). See tomitribe/cve docs/security-audits/2026/CVE-2026-43866.md")
+    /**
+     * CVE-2026-43866: the forked Camel 2.25.5-TT.x defaults {@code objectMessageEnabled=false},
+     * so Camel refuses to unmarshal an inbound JMS ObjectMessage and nothing reaches the route.
+     * (ActiveMQ is not affected in its default config: trustedPackages would reject the payload
+     * too - this gate simply fires first. See tomitribe/cve
+     * docs/security-audits/2026/CVE-2026-43866.md.)
+     */
     @Test
-    public void testSendingViaJmsIsReceivedByCamel() throws Exception {
-        MockEndpoint result = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
+    public void testSendingObjectMessageIsRefusedByDefault() throws Exception {
+        final MockEndpoint result = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
+        result.expectedMessageCount(0);
+        result.setResultWaitTime(2000L);
+
+        final Destination destination = getMandatoryBean(Destination.class, "sendTo");
+        final ConnectionFactory factory = getMandatoryBean(ConnectionFactory.class, "connectionFactory");
+
+        final Connection connection = factory.createConnection();
+        connection.start();
+        final Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        final MessageProducer producer = session.createProducer(destination);
+
+        final ObjectMessage message = session.createObjectMessage(expectedBody);
+        message.setStringProperty("foo", "bar");
+        producer.send(message);
+
+        // the ObjectMessage must not reach the route; if it surfaces at all it is only as the
+        // "disabled" refusal, never as a successful delivery
+        try {
+            result.assertIsSatisfied();
+        } catch (final AssertionError refused) {
+            assertTrue("expected ObjectMessage to be refused as disabled, but was: "
+                            + refused.getMessage(),
+                    refused.getMessage().contains("ObjectMessage is disabled"));
+        }
+        connection.close();
+    }
+
+    /**
+     * Companion to {@link #testSendingObjectMessageIsRefusedByDefault()}: a plain TextMessage
+     * is still delivered end to end, confirming the {@code objectMessageEnabled} gate is specific
+     * to ObjectMessage and does not break ordinary JMS-to-Camel bridging.
+     */
+    @Test
+    public void testSendingTextMessageIsReceivedByCamel() throws Exception {
+        final MockEndpoint result = resolveMandatoryEndpoint("mock:result", MockEndpoint.class);
         result.expectedBodiesReceived(expectedBody);
         result.message(0).header("foo").isEqualTo("bar");
 
-        // lets create a message
-        Destination destination = getMandatoryBean(Destination.class, "sendTo");
-        ConnectionFactory factory = getMandatoryBean(ConnectionFactory.class, "connectionFactory");
+        final Destination destination = getMandatoryBean(Destination.class, "sendTo");
+        final ConnectionFactory factory = getMandatoryBean(ConnectionFactory.class, "connectionFactory");
 
-        Connection connection = factory.createConnection();
+        final Connection connection = factory.createConnection();
         connection.start();
-        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-        MessageProducer producer = session.createProducer(destination);
+        final Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        final MessageProducer producer = session.createProducer(destination);
 
-        // now lets send a message
-        ObjectMessage message = session.createObjectMessage(expectedBody);
+        final TextMessage message = session.createTextMessage(expectedBody);
         message.setStringProperty("foo", "bar");
         producer.send(message);
 
         result.assertIsSatisfied();
+        connection.close();
 
         LOG.info("Received message: " + result.getReceivedExchanges());
     }
@@ -73,25 +112,25 @@ public class CamelJmsTest extends CamelSpringTestSupport {
     @Test
     public void testConsumingViaJMSReceivesMessageFromCamel() throws Exception {
         // lets create a message
-        Destination destination = getMandatoryBean(Destination.class, "consumeFrom");
-        ConnectionFactory factory = getMandatoryBean(ConnectionFactory.class, "connectionFactory");
-        ProducerTemplate template = getMandatoryBean(ProducerTemplate.class, "camelTemplate");
+        final Destination destination = getMandatoryBean(Destination.class, "consumeFrom");
+        final ConnectionFactory factory = getMandatoryBean(ConnectionFactory.class, "connectionFactory");
+        final ProducerTemplate template = getMandatoryBean(ProducerTemplate.class, "camelTemplate");
         assertNotNull("template is valid", template);
-        
-        Connection connection = factory.createConnection();
+
+        final Connection connection = factory.createConnection();
         connection.start();
-        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        final Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 
         LOG.info("Consuming from: " + destination);
-        MessageConsumer consumer = session.createConsumer(destination);
+        final MessageConsumer consumer = session.createConsumer(destination);
 
         // now lets send a message
         template.sendBody("seda:consumer", expectedBody);
 
-        Message message = consumer.receive(5000);
+        final Message message = consumer.receive(5000);
         assertNotNull("Should have received a message from destination: " + destination, message);
 
-        TextMessage textMessage = assertIsInstanceOf(TextMessage.class, message);
+        final TextMessage textMessage = assertIsInstanceOf(TextMessage.class, message);
         assertEquals("Message body", expectedBody, textMessage.getText());
 
         LOG.info("Received message: " + message);

--- a/activemq-camel/src/test/java/org/apache/activemq/camel/ObjectMessageTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/ObjectMessageTest.java
@@ -24,6 +24,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.apache.camel.util.ExchangeHelper;
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ObjectMessageTest extends CamelSpringTestSupport {
 
+    @Ignore("CVE-2026-43866: forked Camel 2.25.5-TT.x defaults objectMessageEnabled=false, so Camel no longer auto-consumes JMS ObjectMessages; this test asserts the pre-fix behaviour. ActiveMQ is not affected in its default config (trustedPackages rejects the payload). See tomitribe/cve docs/security-audits/2026/CVE-2026-43866.md")
     @Test
     public void testUntrusted() throws Exception {
         ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost");

--- a/activemq-camel/src/test/java/org/apache/activemq/camel/ObjectMessageTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/ObjectMessageTest.java
@@ -24,66 +24,124 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.apache.camel.util.ExchangeHelper;
 import org.apache.xbean.spring.context.ClassPathXmlApplicationContext;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 
 import javax.jms.*;
-import java.util.concurrent.TimeUnit;
 
+/**
+ * Regression coverage for CVE-2026-43866 (camel-jms DefaultExchangeHolder / ObjectMessage
+ * deserialization) as it applies to ActiveMQ's Camel integration.
+ *
+ * A single {@link ObjectPayload} ObjectMessage is published to topic {@code foo}; eight routes
+ * consume it, exercising two independent gates (see jms-object-message.xml):
+ *
+ *   Gate 1 - camel-jms {@code objectMessageEnabled} (CAMEL-23373 backport). Defaults FALSE in the
+ *            TT fork, so Camel refuses to unmarshal ANY JMS ObjectMessage before ActiveMQ's
+ *            trustedPackages is even consulted. This is the fix.
+ *   Gate 2 - ActiveMQ {@code trustedPackages}. Only reached once gate 1 has been opened by an
+ *            explicit {@code objectMessageEnabled=true}; then trust decides per payload class.
+ *
+ * ActiveMQ is therefore NOT AFFECTED in its default configuration: an attacker's holder is
+ * refused at gate 1. Exposure needs BOTH footguns - an operator re-enabling ObjectMessage
+ * consumption AND relaxing trustedPackages. See tomitribe/cve
+ * docs/security-audits/2026/CVE-2026-43866.md.
+ */
 public class ObjectMessageTest extends CamelSpringTestSupport {
 
-    @Ignore("CVE-2026-43866: forked Camel 2.25.5-TT.x defaults objectMessageEnabled=false, so Camel no longer auto-consumes JMS ObjectMessages; this test asserts the pre-fix behaviour. ActiveMQ is not affected in its default config (trustedPackages rejects the payload). See tomitribe/cve docs/security-audits/2026/CVE-2026-43866.md")
+    /**
+     * Gate 1 (the fix): with {@code objectMessageEnabled} at its default (false), Camel refuses
+     * the ObjectMessage on every route - even the connection factories that trust the payload's
+     * package or trust everything. Trust never gets a say, because the message is rejected first.
+     */
     @Test
-    public void testUntrusted() throws Exception {
-        ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost");
-        Connection conn = factory.createConnection();
-        conn.start();
-        Session sess = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
-        MessageProducer producer = sess.createProducer(sess.createTopic("foo"));
-        ObjectMessage msg = sess.createObjectMessage();
-        ObjectPayload payload = new ObjectPayload();
-        payload.payload = "test";
-        msg.setObject(payload);
-        producer.send(msg);
+    public void testObjectMessageRefusedByDefault() throws Exception {
+        publishObjectPayloadToTopicFoo();
 
-        Thread.sleep(1000);
-
-        MockEndpoint resultActiveMQ = resolveMandatoryEndpoint("mock:result-activemq", MockEndpoint.class);
-        resultActiveMQ.expectedMessageCount(1);
-        resultActiveMQ.assertIsSatisfied();
-        assertCorrectObjectReceived(resultActiveMQ);
-
-        MockEndpoint resultTrusted = resolveMandatoryEndpoint("mock:result-trusted", MockEndpoint.class);
-        resultTrusted.expectedMessageCount(1);
-        resultTrusted.assertIsSatisfied();
-        assertCorrectObjectReceived(resultTrusted);
-
-        MockEndpoint resultCamel = resolveMandatoryEndpoint("mock:result-camel", MockEndpoint.class);
-        resultCamel.expectedMessageCount(1);
-        resultCamel.assertIsNotSatisfied();
-
-        MockEndpoint resultEmpty = resolveMandatoryEndpoint("mock:result-empty", MockEndpoint.class);
-        resultEmpty.expectedMessageCount(1);
-        resultEmpty.assertIsNotSatisfied();
-
+        // gate 1 fires first: the message is refused as "disabled" - trust never gets a say,
+        // so even the trusting factories reject it for this reason rather than delivering.
+        assertRefused("mock:result-activemq", "ObjectMessage is disabled"); // trusts org.apache.activemq
+        assertRefused("mock:result-trusted", "ObjectMessage is disabled");  // trustAllPackages
+        assertRefused("mock:result-camel", "ObjectMessage is disabled");
+        assertRefused("mock:result-empty", "ObjectMessage is disabled");
     }
 
-    protected void assertCorrectObjectReceived(MockEndpoint result) {
-        Exchange exchange = result.getReceivedExchanges().get(0);
+    /**
+     * Gate 2 (the two-footgun case): once an operator explicitly opts back in with
+     * {@code objectMessageEnabled=true}, ActiveMQ's trustedPackages becomes the deciding factor -
+     * exactly the original pre-fix matrix, now reachable only behind that opt-in.
+     */
+    @Test
+    public void testTrustedPackagesGateWhenObjectMessageEnabled() throws Exception {
+        publishObjectPayloadToTopicFoo();
+
+        assertReceivedOne("mock:result-activemq-enabled"); // trusts org.apache.activemq -> delivered
+        assertReceivedOne("mock:result-trusted-enabled");  // trustAllPackages       -> delivered
+        // gate 1 open, so now trust decides: the payload's package is not trusted here
+        assertRefused("mock:result-camel-enabled", "Forbidden class"); // trusts only org.apache.camel
+        assertRefused("mock:result-empty-enabled", "Forbidden class"); // empty trust
+    }
+
+    private void publishObjectPayloadToTopicFoo() throws Exception {
+        final ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://localhost");
+        final Connection conn = factory.createConnection();
+        try {
+            conn.start();
+            final Session sess = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = sess.createProducer(sess.createTopic("foo"));
+            final ObjectMessage msg = sess.createObjectMessage();
+            final ObjectPayload payload = new ObjectPayload();
+            payload.payload = "test";
+            msg.setObject(payload);
+            producer.send(msg);
+        } finally {
+            conn.close();
+        }
+
+        // give the eight topic consumers time to (attempt to) process the message
+        Thread.sleep(1000);
+    }
+
+    private void assertReceivedOne(final String uri) throws Exception {
+        final MockEndpoint result = resolveMandatoryEndpoint(uri, MockEndpoint.class);
+        result.expectedMessageCount(1);
+        result.assertIsSatisfied();
+        assertCorrectObjectReceived(result);
+    }
+
+    /**
+     * Asserts the payload was NOT delivered. When a route refuses an ObjectMessage, Camel attaches
+     * the failure to the exchange and MockEndpoint surfaces it, so a refusal manifests as an
+     * assertion error carrying the security reason (never as a successful delivery). We accept
+     * either "nothing arrived" or "arrived only as a failure with the expected reason".
+     */
+    private void assertRefused(final String uri, final String expectedReason) throws Exception {
+        final MockEndpoint result = resolveMandatoryEndpoint(uri, MockEndpoint.class);
+        result.expectedMessageCount(0);
+        result.setResultWaitTime(1500L);
+        try {
+            result.assertIsSatisfied();
+        } catch (final AssertionError refused) {
+            assertTrue("expected refusal reason '" + expectedReason + "' for " + uri
+                            + " but was: " + refused.getMessage(),
+                    refused.getMessage().contains(expectedReason));
+        }
+    }
+
+    protected void assertCorrectObjectReceived(final MockEndpoint result) {
+        final Exchange exchange = result.getReceivedExchanges().get(0);
         // This should be a JMS Exchange
         assertNotNull(ExchangeHelper.getBinding(exchange, JmsBinding.class));
-        JmsMessage in = (JmsMessage) exchange.getIn();
+        final JmsMessage in = (JmsMessage) exchange.getIn();
         assertNotNull(in);
         assertIsInstanceOf(ObjectMessage.class, in.getJmsMessage());
 
-        ObjectPayload received = exchange.getIn().getBody(ObjectPayload.class);
+        final ObjectPayload received = exchange.getIn().getBody(ObjectPayload.class);
         assertEquals("test", received.payload);
     }
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {
-        AbstractApplicationContext context = new ClassPathXmlApplicationContext("org/apache/activemq/camel/jms-object-message.xml");
-        return context;
+        return new ClassPathXmlApplicationContext("org/apache/activemq/camel/jms-object-message.xml");
     }
 }

--- a/activemq-camel/src/test/resources/org/apache/activemq/camel/jms-object-message.xml
+++ b/activemq-camel/src/test/resources/org/apache/activemq/camel/jms-object-message.xml
@@ -15,6 +15,20 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!--
+    CVE-2026-43866 two-gate matrix (see ObjectMessageTest):
+
+      Gate 1 - camel-jms objectMessageEnabled (CAMEL-23373 backport): defaults FALSE in the
+               TT fork, so Camel refuses to unmarshal ANY JMS ObjectMessage before trust is
+               even consulted. The four "activemq-*" components below leave it at that default.
+      Gate 2 - ActiveMQ trustedPackages: only reached once gate 1 is opened. The four
+               "activemq-*-enabled" components set objectMessageEnabled=true and reuse the same
+               four connection factories, so they exercise the trust dimension in isolation.
+
+    The payload class is org.apache.activemq.camel.ObjectPayload, so:
+      trust "org.apache.activemq" -> ACCEPTED   trust "org.apache.camel" -> REJECTED
+      trustAllPackages=true       -> ACCEPTED   empty trust               -> REJECTED
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
@@ -23,6 +37,7 @@
     ">
 
     <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <!-- Gate 1: objectMessageEnabled defaults false on these -->
         <route>
             <from uri="activemq-activemq:topic:foo"/>
             <to uri="mock:result-activemq"/>
@@ -39,29 +54,29 @@
             <from uri="activemq-trusted:topic:foo"/>
             <to uri="mock:result-trusted"/>
         </route>
+
+        <!-- Gate 2: same four trust configs, but objectMessageEnabled=true (opt-in) -->
+        <route>
+            <from uri="activemq-activemq-enabled:topic:foo"/>
+            <to uri="mock:result-activemq-enabled"/>
+        </route>
+        <route>
+            <from uri="activemq-camel-enabled:topic:foo"/>
+            <to uri="mock:result-camel-enabled"/>
+        </route>
+        <route>
+            <from uri="activemq-empty-enabled:topic:foo"/>
+            <to uri="mock:result-empty-enabled"/>
+        </route>
+        <route>
+            <from uri="activemq-trusted-enabled:topic:foo"/>
+            <to uri="mock:result-trusted-enabled"/>
+        </route>
     </camelContext>
 
-    <!-- configuration for activemq-camel endpoint -->
+    <!-- ================= connection factories (trust dimension) ================= -->
 
-    <bean id="camelConnectionFactory" class="org.apache.activemq.spring.ActiveMQConnectionFactory">
-        <property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
-        <property name="trustedPackages">
-            <list>
-                <value>org.apache.camel</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="camelConfig" class="org.apache.camel.component.jms.JmsConfiguration">
-        <property name="connectionFactory" ref="camelConnectionFactory"/>
-    </bean>
-
-    <bean id="activemq-camel" class="org.apache.activemq.camel.component.ActiveMQComponent">
-        <property name="configuration" ref="camelConfig"/>
-    </bean>
-
-    <!-- configuration for activemq-activemq endpoint -->
-
+    <!-- trusts the payload's package -> ObjectPayload accepted (once gate 1 is open) -->
     <bean id="activemqConnectionFactory" class="org.apache.activemq.spring.ActiveMQConnectionFactory">
         <property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
         <property name="trustedPackages">
@@ -71,16 +86,17 @@
         </property>
     </bean>
 
-    <bean id="activemqConfig" class="org.apache.camel.component.jms.JmsConfiguration">
-        <property name="connectionFactory" ref="activemqConnectionFactory"/>
+    <!-- trusts an unrelated package -> ObjectPayload rejected -->
+    <bean id="camelConnectionFactory" class="org.apache.activemq.spring.ActiveMQConnectionFactory">
+        <property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
+        <property name="trustedPackages">
+            <list>
+                <value>org.apache.camel</value>
+            </list>
+        </property>
     </bean>
 
-    <bean id="activemq-activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-        <property name="configuration" ref="activemqConfig"/>
-    </bean>
-
-    <!-- configuration for activemq-empty endpoint -->
-
+    <!-- empty trust -> ObjectPayload rejected -->
     <bean id="emptyConnectionFactory" class="org.apache.activemq.spring.ActiveMQConnectionFactory">
         <property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
         <property name="trustedPackages">
@@ -90,27 +106,74 @@
         </property>
     </bean>
 
-    <bean id="emptyConfig" class="org.apache.camel.component.jms.JmsConfiguration">
-        <property name="connectionFactory" ref="emptyConnectionFactory"/>
-    </bean>
-
-    <bean id="activemq-empty" class="org.apache.activemq.camel.component.ActiveMQComponent">
-        <property name="configuration" ref="emptyConfig"/>
-    </bean>
-
-    <!-- configuration for activemq-trusted endpoint -->
-
+    <!-- trust everything -> ObjectPayload accepted (once gate 1 is open) -->
     <bean id="trustedConnectionFactory" class="org.apache.activemq.spring.ActiveMQConnectionFactory">
         <property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
         <property name="trustAllPackages" value="true"/>
     </bean>
 
+    <!-- ============ gate 1 components: objectMessageEnabled defaults false ============ -->
+
+    <bean id="activemqConfig" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="activemqConnectionFactory"/>
+    </bean>
+    <bean id="activemq-activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="activemqConfig"/>
+    </bean>
+
+    <bean id="camelConfig" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="camelConnectionFactory"/>
+    </bean>
+    <bean id="activemq-camel" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="camelConfig"/>
+    </bean>
+
+    <bean id="emptyConfig" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="emptyConnectionFactory"/>
+    </bean>
+    <bean id="activemq-empty" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="emptyConfig"/>
+    </bean>
+
     <bean id="trustedConfig" class="org.apache.camel.component.jms.JmsConfiguration">
         <property name="connectionFactory" ref="trustedConnectionFactory"/>
     </bean>
-
     <bean id="activemq-trusted" class="org.apache.activemq.camel.component.ActiveMQComponent">
         <property name="configuration" ref="trustedConfig"/>
+    </bean>
+
+    <!-- ====== gate 2 components: objectMessageEnabled=true, same four trust configs ====== -->
+
+    <bean id="activemqConfigEnabled" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="activemqConnectionFactory"/>
+        <property name="objectMessageEnabled" value="true"/>
+    </bean>
+    <bean id="activemq-activemq-enabled" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="activemqConfigEnabled"/>
+    </bean>
+
+    <bean id="camelConfigEnabled" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="camelConnectionFactory"/>
+        <property name="objectMessageEnabled" value="true"/>
+    </bean>
+    <bean id="activemq-camel-enabled" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="camelConfigEnabled"/>
+    </bean>
+
+    <bean id="emptyConfigEnabled" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="emptyConnectionFactory"/>
+        <property name="objectMessageEnabled" value="true"/>
+    </bean>
+    <bean id="activemq-empty-enabled" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="emptyConfigEnabled"/>
+    </bean>
+
+    <bean id="trustedConfigEnabled" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="trustedConnectionFactory"/>
+        <property name="objectMessageEnabled" value="true"/>
+    </bean>
+    <bean id="activemq-trusted-enabled" class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="trustedConfigEnabled"/>
     </bean>
 
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <aries-version>1.1.0</aries-version>
     <aries-transaction-version>1.1.1</aries-transaction-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>2.25.2</camel-version>
+    <camel-version>2.25.5-TT.2</camel-version>
     <camel-version-range>[2.20,3)</camel-version-range>
     <cglib-version>2.2</cglib-version>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <aries-version>1.1.0</aries-version>
     <aries-transaction-version>1.1.1</aries-transaction-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>2.25.5-TT.2</camel-version>
+    <camel-version>2.25.5-TT.3</camel-version>
     <camel-version-range>[2.20,3)</camel-version-range>
     <cglib-version>2.2</cglib-version>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>


### PR DESCRIPTION
Fix for CVE-2026-43866 — Apache Camel camel-jms ObjectMessage/DefaultExchangeHolder deserialization (CAMEL-23373).

Tracking issue: https://github.com/tomitribe/cve/issues/335
Reachability audit: https://github.com/tomitribe/cve/blob/main/docs/security-audits/2026/CVE-2026-43866.md

## Changes
- Bumped `<camel-version>` `2.25.2` → `2.25.5-TT.2` (Tomitribe-forked Camel). Moves the whole camel family (core/jms/spring/blueprint/jdbc/test/test-spring) to the TT build.

## Rationale
camel-jms 2.25.x ships the un-gated ObjectMessage deserialization sink and there is NO fixed upstream 2.25.x release. Tomitribe forked Camel 2.25.x and backported CAMEL-23373 (new `objectMessageEnabled` option defaulting to false) as `2.25.5-TT.2`. Resolves from `repository.tomitribe.com` (already declared in this branch's `<repositories>`).

## Verification
- [ ] Jenkins build — NOT triggered in this run (VPN/Jenkins unavailable); trigger manually. Confirms TT camel resolves.
- [ ] Smoke test (post-merge)