### PR TITLE
CVE-2026-43866: bump Apache Camel to 2.25.5-TT.2 (activemq-5.19)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <ant-version>1.10.15</ant-version>
     <aries-version>1.1.0</aries-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>2.25.4</camel-version>
+    <camel-version>2.25.5-TT.2</camel-version>
     <camel-version-range>[2.20,4)</camel-version-range>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>
     <commons-collections-version>3.2.2-TT.1</commons-collections-version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <ant-version>1.10.15</ant-version>
     <aries-version>1.1.0</aries-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>2.25.5-TT.2</camel-version>
+    <camel-version>2.25.5-TT.3</camel-version>
     <camel-version-range>[2.20,4)</camel-version-range>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>
     <commons-collections-version>3.2.2-TT.1</commons-collections-version>


### PR DESCRIPTION
Fix for CVE-2026-43866 — Apache Camel camel-jms ObjectMessage/DefaultExchangeHolder deserialization (CAMEL-23373).

Tracking issue: https://github.com/tomitribe/cve/issues/335
Reachability audit: https://github.com/tomitribe/cve/blob/main/docs/security-audits/2026/CVE-2026-43866.md

## Changes
- Bumped `<camel-version>` `2.25.4` → `2.25.5-TT.2` (Tomitribe-forked Camel). Moves the whole camel family to the TT build.

## Rationale
camel-jms 2.25.x ships the un-gated ObjectMessage deserialization sink and there is NO fixed upstream 2.25.x release. Tomitribe forked Camel 2.25.x and backported CAMEL-23373 (`objectMessageEnabled` defaulting to false) as `2.25.5-TT.2`. Resolves from `repository.tomitribe.com` (already declared in this branch's `<repositories>`).

## Verification
- [ ] Jenkins build — NOT triggered in this run; trigger manually. Confirms TT camel resolves.
- [ ] Smoke test (post-merge)