### PR TITLE
Fix broker startup on 5.15: add id="broker" to activemq.xml

### DIFF
--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -37,7 +37,7 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" id="broker">
 
         <destinationPolicy>
             <policyMap>


### PR DESCRIPTION
## Problem

The default broker does not start on `activemq-5.15.x-TT.x`:

```
NoSuchBeanDefinitionException: No bean named 'broker' available
  — invokeStart (jetty.xml) depends-on 'broker'
```

## Root cause

Commit `ca1651857d` — *"CVE-2026-49157: [5.19.x] Harden web console and Jolokia access by default (#2025) (#2038)"* — is a backport of an upstream Apache hardening change. It added `depends-on="broker"` to the `invokeStart` bean in `conf/jetty.xml` (to start Jetty after the broker), but the `<broker>` element in this branch's `conf/activemq.xml` has **no `id`**, so xbean never registers a bean named `broker`. The dependency can't resolve → startup aborts.

## Why `id="broker"` is the right fix (upstream parity)

- Upstream `apache/activemq-5.19.x` ships the **same** `jetty.xml` (`depends-on="broker"`) **and** `activemq.xml` with `id="broker"`. The upstream PRs (#2025/#2038) only edited `jetty.xml` because upstream's `activemq.xml` already carried `id="broker"`.
- The 5.15 backport brought only the `jetty.xml` half.
- Sweep of TT branches: **5.16, 5.17, 5.18, 5.19, 6.0, 6.1, 6.2, 6.3 all already have `id="broker"`** — `5.15.x-TT.x` is the only one missing it.

## Change

One line in `assembly/src/release/conf/activemq.xml`:

```diff
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" id="broker">
```

`id` is a reserved xbean attribute (names the bean; not passed as a broker property), so this simply names the broker bean `broker`, satisfying `invokeStart`'s `depends-on="broker"`. Broker then starts out of the box.